### PR TITLE
support for user-created zones; pass a.p.firewalld tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,14 @@ These are the variables that can be passed to the role:
 
 ### zone
 
-Name of the zone that should be modified. If it is not set, the default zone will be used. It will have an effect on these parameters: `service`, `port` and `forward_port`.
+Name of the zone that should be modified. If it is not set, the default zone
+will be used. It will have an effect on these variables: `service`, `port`,
+`source_port`, `forward_port`, `masquerade`, `rich_rule`, `source`, `interface`,
+`icmp_block`, `icmp_block_inversion`, and `target`.
+
+You can also use this to add/remove user-created zones.  Specify the `zone`
+variable with no other variables, and use `state: present` to add the zone, or
+`state: absent` to remove it.
 
 ```
 zone: 'public'
@@ -42,7 +49,8 @@ zone: 'public'
 
 ### service
 
-Name of a service or service list to add or remove inbound access to. The service needs to be defined in firewalld.
+Name of a service or service list to add or remove inbound access to. The
+service needs to be defined in firewalld.
 
 ```
 service: 'ftp'
@@ -51,20 +59,131 @@ service: [ 'ftp', 'tftp' ]
 
 ### port
 
-Port or port range or a list of them to add or remove inbound access to. It needs to be in the format ```<port>[-<port>]/<protocol>```.
+Port or port range or a list of them to add or remove inbound access to. It
+needs to be in the format ```<port>[-<port>]/<protocol>```.
 
 ```
 port: '443/tcp'
 port: [ '443/tcp', '443/udp' ]
 ```
 
+### source_port
+
+Port or port range or a list of them to add or remove source port access to. It
+needs to be in the format ```<port>[-<port>]/<protocol>```.
+
+```
+source_port: '443/tcp'
+source_port: [ '443/tcp', '443/udp' ]
+```
+
 ### forward_port
 
-Add or remove port forwarding for ports or port ranges for a zone. It needs to be in the format ```<port>[-<port>]/<protocol>;[<to-port>];[<to-addr>]```.
+Add or remove port forwarding for ports or port ranges for a zone. It takes two
+different formats:
+* string or a list of strings in the format like `firewall-cmd
+  --add-forward-port` e.g. `<port>[-<port>]/<protocol>;[<to-port>];[<to-addr>]`
+* dict or list of dicts in the format like `ansible.posix.firewalld`:
 
+```
+forward_port:
+  port: <port>
+  proto: <protocol>
+  [toport: <to-port>]
+  [toaddr: <to-addr>]
+```
+examples
 ```
 forward_port: '447/tcp;;1.2.3.4'
 forward_port: [ '447/tcp;;1.2.3.4', '448/tcp;;1.2.3.5' ]
+forward_port:
+  - port: 447
+    proto: tcp
+    toaddr: 1.2.3.4
+  - port: 448
+    proto: tcp
+    toaddr: 1.2.3.5
+```
+`port_forward` is an alias for `forward_port`.  Its use is deprecated and will
+be removed in an upcoming release.
+
+### masquerade
+
+Enable or disable masquerade on the given zone.
+
+```
+masquerade: false
+```
+
+### rich_rule
+
+String or list of rich rule strings. For the format see (Syntax for firewalld
+rich language
+rules)[https://firewalld.org/documentation/man-pages/firewalld.richlanguage.html]
+
+```
+rich_rule: rule service name="ftp" audit limit value="1/m" accept
+```
+
+### source
+
+List of source address or address range strings.  A source address or address
+range is either an IP address or a network IP address with a mask for IPv4 or
+IPv6. For IPv4, the mask can be a network mask or a plain number. For IPv6 the
+mask is a plain number.
+
+```
+source: 192.0.2.0/24
+```
+
+### interface
+
+String or list of interface name strings.
+
+```
+interface: eth2
+```
+
+### icmp_block
+
+String or list of ICMP type strings to block.  The ICMP type names needs to be
+defined in firewalld configuration.
+
+```
+icmp_block: echo-request
+```
+
+### icmp_block_inversion
+
+ICMP block inversion bool setting.  It enables or disables inversion of ICMP
+blocks for a zone in firewalld.
+
+```
+icmp_block_inversion: true
+```
+
+### target
+
+The firewalld zone target.  If the state is set to `absent`,this will reset the
+target to default.  Valid values are "default", "ACCEPT", "DROP", "%%REJECT%%".
+
+```
+target: ACCEPT
+```
+
+### timeout
+
+The amount of time in seconds a setting is in effect. The timeout is usable if
+
+* state is set to `enabled`
+* firewalld is running and `runtime` is set
+* setting is used with services, ports, source ports, forward ports, masquerade,
+  rich rules or icmp blocks
+
+```
+timeout: 60
+state: enabled
+service: https
 ```
 
 ### state
@@ -72,8 +191,20 @@ forward_port: [ '447/tcp;;1.2.3.4', '448/tcp;;1.2.3.5' ]
 Enable or disable the entry.
 
 ```
-state: 'enabled' | 'disabled'
+state: 'enabled' | 'disabled' | 'present' | 'absent'
 ```
+NOTE: `present` and `absent` are only used for `zone` and `target` operations,
+and cannot be used for any other operation.
+
+NOTE: `zone` - use `state: present` to add a zone, and `state: absent` to remove
+a zone, when zone is the only variable e.g.
+```
+firewall:
+  zone: my-new-zone
+  state: present
+```
+NOTE: `target` - you can also use `state: present` to add a target - `state:
+absent` will reset the target to the default.
 
 Example Playbooks
 -----------------

--- a/library/firewall_lib.py
+++ b/library/firewall_lib.py
@@ -187,19 +187,34 @@ def parse_port(module, item):
 def parse_forward_port(module, item):
     type_string = "forward_port"
 
-    args = item.split(";")
-    if len(args) == 3:
-        __port, _to_port, _to_addr = args
+    if isinstance(item, dict):
+        if "port" not in item:
+            module.fail_json(msg="%s is missing field 'port' in %s" % (type_string, item))
+        else:
+            _port = str(item["port"])
+        if "proto" not in item:
+            module.fail_json(msg="%s is missing field 'proto' in %s" % (type_string, item))
+        else:
+            _protocol = item["proto"]
+        if "toport" in item:
+            _to_port = str(item["toport"])
+        else:
+            _to_port = None
+        _to_addr = item.get("toaddr")
     else:
-        module.fail_json(msg="improper %s format: %s" % (type_string, item))
+        args = item.split(";")
+        if len(args) == 3:
+            __port, _to_port, _to_addr = args
+        else:
+            module.fail_json(msg="improper %s format: %s" % (type_string, item))
 
-    _port, _protocol = __port.split("/")
-    if _protocol is None:
-        module.fail_json(msg="improper %s format (missing protocol?)" % type_string)
-    if _to_port == "":
-        _to_port = None
-    if _to_addr == "":
-        _to_addr = None
+        _port, _protocol = __port.split("/")
+        if _protocol is None:
+            module.fail_json(msg="improper %s format (missing protocol?)" % type_string)
+        if _to_port == "":
+            _to_port = None
+        if _to_addr == "":
+            _to_addr = None
 
     return (_port, _protocol, _to_port, _to_addr)
 
@@ -210,7 +225,12 @@ def main():
             service=dict(required=False, type="list", default=[]),
             port=dict(required=False, type="list", default=[]),
             source_port=dict(required=False, type="list", default=[]),
-            forward_port=dict(required=False, type="list", default=[]),
+            forward_port=dict(required=False, type="list", default=[],
+              aliases=["port_forward"],
+              deprecated_aliases=[
+                  {"name": "port_forward", "date": "2021-09-23", "collection": "ansible.posix"},
+              ],
+            ),
             masquerade=dict(required=False, type="bool", default=None),
             rich_rule=dict(required=False, type="list", default=[]),
             source=dict(required=False, type="list", default=[]),
@@ -227,12 +247,22 @@ def main():
             zone=dict(required=False, type="str", default=None),
             permanent=dict(required=False, type="bool", default=None),
             runtime=dict(
-                required=False, type="bool", aliases=["immediate"], default=None
+                required=False, type="bool", default=None,
+                aliases=["immediate"],
+                deprecated_aliases=[
+                    {"name": "immediate", "date": "2021-09-23", "collection": "ansible.posix"},
+                ],
             ),
             offline=dict(required=False, type="bool", default=None),
-            state=dict(choices=["enabled", "disabled"], required=True),
+            state=dict(
+                choices=["enabled", "disabled", "present", "absent"], required=True
+            ),
         ),
         supports_check_mode=True,
+        required_if=(
+            ("state", "present", ("target", "zone"), True),
+            ("state", "absent", ("target", "zone"), True),
+        ),
     )
 
     if not HAS_FIREWALLD:
@@ -270,34 +300,36 @@ def main():
 
     if permanent is None:
         runtime = True
-    elif not permanent:
-        if (runtime is not None and not runtime) and (
-            offline is not None and not offline
-        ):
-            module.fail_json(
-                msg="One of permanent, runtime or offline needs to be enabled"
-            )
+    elif not any((permanent, runtime, offline)):
+        module.fail_json(
+            msg="One of permanent, runtime or offline needs to be enabled"
+        )
 
     if (
         masquerade is None
         and icmp_block_inversion is None
         and target is None
         and zone is None
-        and len(service)
-        + len(port)
-        + len(source_port)
-        + len(forward_port)
-        + len(rich_rule)
-        + len(source)
-        + len(interface)
-        + len(icmp_block)
-        == 0
+        and not any((service, port, source_port, forward_port, rich_rule, source, interface, icmp_block))
     ):
         module.fail_json(
             msg="One of service, port, source_port, forward_port, "
             "masquerade, rich_rule, source, interface, icmp_block, "
             "icmp_block_inversion, target or zone needs to be set"
         )
+
+    zone_operation = False
+    if state == "present" or state == "absent":
+        if (
+            masquerade is not None
+            and icmp_block_inversion is not None
+            and any((service, port, source_port, forward_port, rich_rule, source, interface, icmp_block))
+        ):
+            module.fail_json(
+                msg="The states present and absent can only be used in zone level operations (i.e. when no other parameters but zone and state are set)."
+            )
+        if target is None and zone is not None:
+            zone_operation = True
 
     # Parameter checks
     if state == "disabled":
@@ -318,14 +350,7 @@ def main():
 
     if timeout > 0:
         _timeout_ok = (
-            masquerade
-            or len(service)
-            + len(port)
-            + len(source_port)
-            + len(forward_port)
-            + len(rich_rule)
-            + len(icmp_block)
-            > 0
+            any((masquerade, service, port, source_port, forward_port, rich_rule, icmp_block))
         )
 
         if icmp_block_inversion is not None and not _timeout_ok:
@@ -349,15 +374,16 @@ def main():
 
     fw_offline = False
     if not fw.connected:
-        if not offline:
+        if offline is False:
             module.fail_json(
-                msg="Firewalld is not running and offline operation is " "declined."
+                msg="Firewalld is not running and offline operation is declined."
             )
 
         # Firewalld is not currently running, permanent-only operations
         fw_offline = True
         runtime = False
         permanent = True
+        offline = True
 
         # Pre-run version checking
         if LooseVersion(FW_VERSION) < LooseVersion("0.3.9"):
@@ -392,36 +418,50 @@ def main():
         fw.setExceptionHandler(exception_handler)
 
     # Get default zone, the permanent zone and settings
+    fw_zone = None
+    fw_settings = None
     if fw_offline:
-        default_zone = fw.get_default_zone()
-
-        if zone is not None:
-            if zone not in fw.zone.get_zones():
-                module.fail_json(msg="Permanent zone '%s' does not exist." % zone)
-        else:
-            zone = default_zone
-
-        fw_zone = fw.config.get_zone(zone)
-        fw_settings = FirewallClientZoneSettings(
-            list(fw.config.get_zone_config(fw_zone))
-        )
+        # if zone is None, we will use default zone which always exists
+        zone_exists = zone is None or zone in fw.zone.get_zones()
+        if not zone_exists and not zone_operation:
+            module.fail_json(msg="Permanent zone '%s' does not exist." % zone)
+        elif zone_exists:
+            zone = zone or fw.get_default_zone()
+            fw_zone = fw.config.get_zone(zone)
+            fw_settings = FirewallClientZoneSettings(
+                list(fw.config.get_zone_config(fw_zone))
+            )
     else:
-        default_zone = fw.getDefaultZone()
+        zone_exists = False
+        if runtime:
+            zone_exists = zone_exists or zone is None or zone in fw.getZones()
+            err_str = "Runtime"
+        if permanent:
+            zone_exists = zone_exists or zone is None or zone in fw.config().getZoneNames()
+            err_str = "Permanent"
 
-        if zone is not None:
-            if runtime and zone not in fw.getZones():
-                module.fail_json(msg="Runtime zone '%s' does not exist." % zone)
-            if permanent and zone not in fw.config().getZoneNames():
-                module.fail_json(msg="Permanent zone '%s' does not exist." % zone)
-        else:
-            zone = default_zone
-
-        fw_zone = fw.config().getZoneByName(zone)
-        fw_settings = fw_zone.getSettings()
-
+        if not zone_exists and not zone_operation:
+            module.fail_json(msg="%s zone '%s' does not exist." % (err_str, zone))
+        elif zone_exists:
+            zone = zone or fw.getDefaultZone()
+            fw_zone = fw.config().getZoneByName(zone)
+            fw_settings = fw_zone.getSettings()
     # Firewall modification starts here
 
     changed = False
+
+    # zone
+    if zone_operation:
+        if state == "present" and not zone_exists:
+            if not module.check_mode:
+                fw.config().addZone(zone, FirewallClientZoneSettings())
+            changed = True
+        elif state == "absent" and zone_exists:
+            if not module.check_mode:
+                fw_zone.remove()
+            changed = True
+            fw_zone = None
+            fw_settings = None
 
     # service
     for item in service:
@@ -564,7 +604,7 @@ def main():
     # source
     for item in source:
         if state == "enabled":
-            if not fw.querySource(zone, item):
+            if runtime and not fw.querySource(zone, item):
                 if not module.check_mode:
                     fw.addSource(zone, item)
                 changed = True
@@ -573,7 +613,7 @@ def main():
                     fw_settings.addSource(item)
                 changed = True
         elif state == "disabled":
-            if fw.querySource(zone, item):
+            if runtime and fw.querySource(zone, item):
                 if not module.check_mode:
                     fw.removeSource(zone, item)
                 changed = True
@@ -647,19 +687,20 @@ def main():
 
     # target
     if target is not None:
-        if state == "enabled":
+        if state in ["enabled", "present"]:
             if permanent and fw_settings.getTarget() != target:
                 if not module.check_mode:
                     fw_settings.setTarget(target)
                 changed = True
-        elif state == "disabled":
+        elif state in ["absent", "disabled"]:
+            target = "default"
             if permanent and fw_settings.getTarget() != target:
                 if not module.check_mode:
                     fw_settings.setTarget(target)
                 changed = True
 
     # apply permanent changes
-    if permanent:
+    if permanent and fw_zone and fw_settings:
         if fw_offline:
             fw.config.set_zone_config(fw_zone, fw_settings.settings)
         else:

--- a/tests/tests_ansible.yml
+++ b/tests/tests_ansible.yml
@@ -326,6 +326,18 @@
         register: result
         failed_when: result.failed or result.changed
 
+      - name: Firewalld custom zone
+        firewall_lib:
+          zone: customzone
+          state: present
+          permanent: yes
+        register: result
+        
+      - name: assert firewalld custom zone
+        assert:
+          that:
+          - result is changed
+
     always:
 
       # CLEANUP: RESET TO ZONE DEFAULTS


### PR DESCRIPTION
Adds support for user-created zones - user can add/remove zones.
Makes the role pass a.p.firewalld integration tests.
Code cleanup